### PR TITLE
recognize thumbnail begin from cura

### DIFF
--- a/octoprint_prusaslicerthumbnails/__init__.py
+++ b/octoprint_prusaslicerthumbnails/__init__.py
@@ -53,7 +53,7 @@ class PrusaslicerthumbnailsPlugin(octoprint.plugin.SettingsPlugin,
 	def _extract_thumbnail(self, gcode_filename, thumbnail_filename):
 		import re
 		import base64
-		regex = r"(?:^; thumbnail begin \d+x\d+ \d+)(?:\n|\r\n?)((?:.+(?:\n|\r\n?))+?)(?:^; thumbnail end)"
+		regex = r"(?:^; thumbnail begin \d+[x ]\d+ \d+)(?:\n|\r\n?)((?:.+(?:\n|\r\n?))+?)(?:^; thumbnail end)"
 		lineNum = 0
 		collectedString = ""
 		with open(gcode_filename,"rb") as gcode_file:


### PR DESCRIPTION
Cura (at least 4.9 I don't know if lower versions have it too) can also add thumbnails but the begin line doesn't have an x between the dimensions. 

With this change they get recognized and displayed.