### PR TITLE
Enable parsing of JPG format by Prusa Slicer

### DIFF
--- a/octoprint_prusaslicerthumbnails/__init__.py
+++ b/octoprint_prusaslicerthumbnails/__init__.py
@@ -65,7 +65,7 @@ class PrusaslicerthumbnailsPlugin(octoprint.plugin.SettingsPlugin,
 		]
 
 	def _extract_thumbnail(self, gcode_filename, thumbnail_filename):
-		regex = r"(?:^; thumbnail begin \d+[x ]\d+ \d+)(?:\n|\r\n?)((?:.+(?:\n|\r\n?))+?)(?:^; thumbnail end)"
+		regex = r"(?:^; thumbnail(?:_JPG)* begin \d+[x ]\d+ \d+)(?:\n|\r\n?)((?:.+(?:\n|\r\n?))+?)(?:^; thumbnail(?:_JPG)* end)"
 		regex_mks = re.compile('(?:;(?:simage|;gimage):).*?M10086 ;[\r\n]', re.DOTALL)
 		regex_weedo = re.compile('W221[\r\n](.*)[\r\n]W222', re.DOTALL)
 		regex_luban = re.compile(';thumbnail: data:image/png;base64,(.*)[\r\n]', re.DOTALL)


### PR DESCRIPTION
This small change extends regex filter to also match "thumbnail_JPG" header produced by PrusaSlicer, if an option of thumbnail format is set to JPG.

![image](https://user-images.githubusercontent.com/22874140/212563619-241fd107-32cf-4086-b4c2-75510721466d.png)

The GCODE section for this format looks like this (note the added _JPG suffix):

```
; thumbnail_JPG begin 256x256 39920
; --- image data ---
; thumbnail_JPG end
```
Tested this PR works both with PNG and JPG options on PrusaSlicer 2.5.0