### PR TITLE
Exclude thumbnails from backup logic

### DIFF
--- a/octoprint_prusaslicerthumbnails/__init__.py
+++ b/octoprint_prusaslicerthumbnails/__init__.py
@@ -385,6 +385,13 @@ class PrusaslicerthumbnailsPlugin(octoprint.plugin.SettingsPlugin,
 				{'name': "Release Candidate", 'branch': "rc", 'comittish': ["rc", "master"]}
 			], 'pip': "https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails/archive/{target_version}.zip"}}
 
+	# ~~ Backup hook
+
+	def additional_backup_excludes(self, excludes, *args, **kwargs):
+		if "uploads" in excludes:
+			return ["."]
+		return []
+
 
 __plugin_name__ = "Slicer Thumbnails"
 __plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
@@ -401,4 +408,5 @@ def __plugin_load__():
 		"octoprint.server.http.routes": __plugin_implementation__.route_hook,
 		"octoprint.server.api.before_request": __plugin_implementation__.hook_octoprint_server_api_before_request,
 		"octoprint.access.permissions": __plugin_implementation__.get_additional_permissions,
+		"octoprint.plugin.backup.additional_excludes": __plugin_implementation__.additional_backup_excludes,
 	}


### PR DESCRIPTION
Skip backing up cached thumbnails if 'uploads' is excluded from the backup.

This should make sense for any reasonable use case. If you aren't backing up your gcode uploads, then the thumbnails are useless anyway, and the user likely is trying to keep down the size of their backup archives. If you are backing up your gcode, the thumbnail is likely a good deal smaller than the gcode and the user likely isn't too worried about the size of their backup archive and this will give a faithful snapshot of the state of Octoprint at the time of backup in reguards to gcode and thumbnails.

The discussion in #120 talked about making a new setting to exclude from backups and to default it to off. After thinking on it some more, using the 'uploads' as a cue is cleaner and will meet users' intuitive expectations. FWIW here is an implementation of the settings based option: https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails/compare/master...lifeisafractal:OctoPrint-PrusaSlicerThumbnails:backup-exclude?expand=1

Fixes #120 